### PR TITLE
ci(lint): drop forced Go version in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,6 +49,3 @@ linters-settings:
 
 issues:
   exclude-use-default: false
-
-run:
-  go: "1.17" # See https://github.com/golangci/golangci-lint/issues/2649.


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
drops forced Go version in `golangci-lint`

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
https://github.com/golangci/golangci-lint/issues/2649 was resolved
