### PR TITLE
ci(releaser): add automatic semver

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -12,8 +12,12 @@ jobs:
       - uses: actions/checkout@v3
       - id: sha
         run: echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      - id: version
+        uses: anothrNick/github-tag-action@1.61.0
+        with:
+          WITH_V: true
       - uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.sha.outputs.sha }}
-          name: Release ${{ steps.sha.outputs.sha }}
+          tag_name: ${{ steps.version.outputs.new_tag }}
+          name: ${{ steps.version.outputs.new_tag }}
           body: auto-generated release for commit ${{ steps.sha.outputs.sha }}


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

# Fill the pull request form below and remove this heading

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
adds automatic semantic versioning to the releaser

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
looks like Go doesn't works properly with anything else besides semantic versions
