### PR TITLE
ci(commitlint): ignore dependabot's commit messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
+};


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
makes `commitlint` ignore depenadbot's commit messages

<!-- Provide the issue number below if it exists. -->

should be removed when https://github.com/dependabot/dependabot-core/issues/2445 is resolved

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
this has been annoying recently
