### PR TITLE
ci(updater): cron only on weekdays

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -2,7 +2,7 @@ name: Updater
 
 on:
   schedule:
-    - cron: 0 3 * * *
+    - cron: 0 3 * * 1-5
 
 jobs:
   updater:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
changes `updater` workflow to run cron only on weekdays

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
we don't work on weekends 😄 
