### PR TITLE
ci(dependabot): run on weekly basis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      main:
+        applies-to: version-updates
+        patterns:
+          - '*'
+      sec:
+        applies-to: security-updates
+        patterns:
+          - '*'
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      main:
+        applies-to: version-updates
+        patterns:
+          - '*'
+      sec:
+        applies-to: security-updates
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
       main:
         applies-to: version-updates
         patterns:
-          - '*'
+          - "*"
       sec:
         applies-to: security-updates
         patterns:
-          - '*'
+          - "*"
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -21,8 +21,8 @@ updates:
       main:
         applies-to: version-updates
         patterns:
-          - '*'
+          - "*"
       sec:
         applies-to: security-updates
         patterns:
-          - '*'
+          - "*"


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
- Sets `dependabot` to run on a weekly basis instead of its default daily basis
- Groups dependencies together to create one PR instead of multiple ones

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- To save the amount of time that it takes to review PRs
- To reduce the notification noise that it creates
