### PR TITLE
ci: add trunk-upgrade workflow

### DIFF
--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -1,0 +1,27 @@
+# https://github.com/trunk-io/trunk-action/tree/34242ec4eb8cf594887600f1f9b889e7c630ec18?tab=readme-ov-file#automatic-upgrades
+name: trunk upgrade
+
+on:
+  schedule:
+    - cron: 0 8 * * 1
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  trunk_upgrade:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # For trunk to create PRs
+      pull-requests: write # For trunk to create PRs
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: trunk-io/trunk-action/upgrade@v1
+        with:
+          prefix: "ci(deps): "
+          lowercase-title: true


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
- Adds `trunk-upgrade` workflow (set to run on a weekly basis)

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- To keep linters up-to-date
