### PR TITLE
ci(updater): run on weekly basis

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -2,7 +2,7 @@ name: Updater
 
 on:
   schedule:
-    - cron: 0 3 * * 1-5
+    - cron: 0 3 * * 1
 
 jobs:
   updater:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
- Sets `updater` to run on a weekly basis instead of its default daily basis

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- To save the amount of time that it takes to review PRs
- To reduce the notification noise that it creates
