### PR TITLE
chore(service_types): undeprecate additional_backup_regions

### DIFF
--- a/pkg/dist/service_types.yml
+++ b/pkg/dist/service_types.yml
@@ -1121,8 +1121,6 @@ grafana:
   type: object
   properties:
     additional_backup_regions:
-      is_deprecated: true
-      deprecation_notice: This property is deprecated.
       title: Additional Cloud Regions for Backup Replication
       type: array
       items:
@@ -3072,8 +3070,6 @@ m3db:
   type: object
   properties:
     additional_backup_regions:
-      is_deprecated: true
-      deprecation_notice: This property is deprecated.
       title: Additional Cloud Regions for Backup Replication
       type: array
       items:
@@ -3885,8 +3881,6 @@ opensearch:
   type: object
   properties:
     additional_backup_regions:
-      is_deprecated: true
-      deprecation_notice: This property is deprecated.
       title: Additional Cloud Regions for Backup Replication
       type: array
       items:
@@ -5520,8 +5514,6 @@ redis:
   type: object
   properties:
     additional_backup_regions:
-      is_deprecated: true
-      deprecation_notice: This property is deprecated.
       title: Additional Cloud Regions for Backup Replication
       type: array
       items:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
- Undeprecates `additional_backup_regions` field across `service_types.yml`

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
This is needed for BTAR
