### PR TITLE
feat: close previous update PRs when a new one is generated

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -5,9 +5,14 @@ on:
     - cron: 0 3 * * 1
   workflow_dispatch: {}
 
+permissions: read-all
+
 jobs:
   updater:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,13 +27,28 @@ jobs:
           AIVEN_PROJECT_NAME: ${{ secrets.AIVEN_PROJECT_NAME }}
       - id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      - uses: peter-evans/create-pull-request@v7
+      - id: create_pr
+        uses: peter-evans/create-pull-request@v7
         with:
           author: GitHub <noreply@github.com>
           body: >
             automated changes by
             [updater](https://github.com/aiven/go-api-schemas/blob/main/.github/workflows/updater.yml)
             GitHub Actions workflow
-          branch: updater/${{ steps.date.outputs.date }}
+          branch: updater/${{ steps.date.outputs.date }}-${{ github.run_id }}
           commit-message: "chore(updater): bump pkg/dist/*.yml (${{ steps.date.outputs.date }})"
           title: "chore(updater): bump pkg/dist/*.yml (${{ steps.date.outputs.date }})"
+          labels: |
+            schema bump
+            automated pr
+      - name: Close previous update PRs
+        run: |
+          new_pr_number=${{ steps.create_pr.outputs.pull-request-number }}
+          prs=$(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("updater/")) | .number')
+          for pr in $prs; do
+            if [ "$pr" != "$new_pr_number" ]; then
+              gh pr close $pr --comment "Auto-closing pull request in favor of #$new_pr_number" --delete-branch
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## About this change - What it does

Closes previous automated schema bump PRs when a new one is raised. 

Essentially the same as https://github.com/aiven/go-client-codegen/pull/142, see that description for more info.

Example run: https://github.com/aiven/go-api-schemas/actions/runs/11029353480/job/30631576923
Example closed PR: https://github.com/aiven/go-api-schemas/pull/192#issuecomment-2373428227