### PR TITLE
chore: run updater Monday through Friday

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -2,7 +2,7 @@ name: Updater
 
 on:
   schedule:
-    - cron: 0 3 * * 1
+    - cron: 0 3 * * 1-5
   workflow_dispatch: {}
 
 permissions: read-all


### PR DESCRIPTION
## About this change - What it does

Runs `updater` GHA workflow Monday through Friday

## Why this way

* To deliver features faster
