### PR TITLE
fix: attempt to close previous PRs only if a new one was created

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -42,6 +42,7 @@ jobs:
             schema bump
             automated pr
       - name: Close previous update PRs
+        if: steps.create_pr.outputs.pull-request-operation == 'created'
         run: |
           new_pr_number=${{ steps.create_pr.outputs.pull-request-number }}
           prs=$(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("updater/")) | .number')


### PR DESCRIPTION
#219 was closed by a run that didn't create a new PR.

