### PR TITLE
fix: sort new enum field values

### DIFF
--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/huandu/xstrings"
@@ -173,6 +174,11 @@ func toUserConfig(src *schema) (*types.UserConfigSchema, error) { // nolint: fun
 			uc.Enum = append(uc.Enum, types.UserConfigSchemaEnumValue{Value: v})
 		}
 	}
+
+	// Sorts enum values for consistent output
+	sort.Slice(uc.Enum, func(i, j int) bool {
+		return fmt.Sprint(uc.Enum[i].Value) < fmt.Sprint(uc.Enum[j].Value)
+	})
 
 	if src.Items != nil {
 		item, err := toUserConfig(src.Items)


### PR DESCRIPTION
The generator doesn't sort freshly added enum field values, it does so only on the diff operation.
For example, [here](https://github.com/aiven/go-api-schemas/pull/300/files) the `log` value was added with the `log_level` field.
And [here](https://github.com/aiven/go-api-schemas/pull/305/files) it was sorted by the differ.
This causes [unnecessary diff](https://github.com/aiven/terraform-provider-aiven/pull/2164/files) in TF when the schema is updated.
