### PR TITLE
fix(valkey): add `valkey_version` to `v1.167` schemas

### DIFF
--- a/pkg/dist/service_types.yml
+++ b/pkg/dist/service_types.yml
@@ -7982,3 +7982,9 @@ valkey:
       default: "300"
       minimum: "0"
       maximum: "2073600"
+    valkey_version:
+      title: Valkey major version
+      type: string
+      enum:
+        - value: "8.1"
+        - value: "9.0"


### PR DESCRIPTION
Resolves: NEX-2510

Backports the Valkey user config field `valkey_version` to the `v1.167` schema line so Terraform Provider 4.51 can regenerate `Valkey` user config without pulling newer schema changes.